### PR TITLE
i18n: Change text strings for recipe view

### DIFF
--- a/assets/i18n/en.json
+++ b/assets/i18n/en.json
@@ -61,6 +61,9 @@
   },
   "recipe": {
     "title": "Recipe:",
+    "prep": "Preparation time",
+    "cook": "Cooking time",
+    "total": "Total time",
     "fields": {
       "name": "Recipe Name:",
       "description": "Recipe Description:",

--- a/lib/src/screens/recipe_screen.dart
+++ b/lib/src/screens/recipe_screen.dart
@@ -162,15 +162,15 @@ class RecipeScreenState extends State<RecipeScreen> {
                         if (recipe.prepTime != null)
                           DurationIndicator(
                               duration: recipe.prepTime,
-                              name: translate('recipe.fields.time.prep')),
+                              name: translate('recipe.prep')),
                         if (recipe.cookTime != null)
                           DurationIndicator(
                               duration: recipe.cookTime,
-                              name: translate('recipe.fields.time.cook')),
+                              name: translate('recipe.cook')),
                         if (recipe.totalTime != null)
                           DurationIndicator(
                               duration: recipe.totalTime,
-                              name: translate('recipe.fields.time.total')),
+                              name: translate('recipe.total')),
                       ],
                     ),
                   ),


### PR DESCRIPTION
Separate strings have been added for preparation, cooking and total time in the recipe view. Colons are not needed in the table.