### PR TITLE
New network cache

### DIFF
--- a/lib/src/screens/category_screen.dart
+++ b/lib/src/screens/category_screen.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_cache_manager/flutter_cache_manager.dart';
 import 'package:flutter_spinkit/flutter_spinkit.dart';
 import 'package:flutter_translate/flutter_translate.dart';
 import 'package:nextcloud_cookbook_flutter/src/blocs/authentication/authentication.dart';
@@ -206,6 +207,7 @@ class _CategoryScreenState extends State<CategoryScreen> {
                   semanticLabel: translate('app_bar.refresh'),
                 ),
                 onPressed: () {
+                  DefaultCacheManager().emptyCache();
                   BlocProvider.of<CategoriesBloc>(context)
                       .add(CategoriesLoaded());
                 },

--- a/lib/src/screens/category_screen.dart
+++ b/lib/src/screens/category_screen.dart
@@ -219,7 +219,7 @@ class _CategoryScreenState extends State<CategoryScreen> {
               DefaultCacheManager().emptyCache();
               BlocProvider.of<CategoriesBloc>(context)
                 .add(CategoriesLoaded());
-              return;
+              return Future.value(true);
             },
             child: () {
               if (categoriesState is CategoriesLoadSuccess) {

--- a/lib/src/screens/category_screen.dart
+++ b/lib/src/screens/category_screen.dart
@@ -214,44 +214,51 @@ class _CategoryScreenState extends State<CategoryScreen> {
               ),
             ],
           ),
-          body: (() {
-            if (categoriesState is CategoriesLoadSuccess) {
-              return _buildCategoriesScreen(categoriesState.categories);
-            } else if (categoriesState is CategoriesImageLoadSuccess) {
-              return _buildCategoriesScreen(categoriesState.categories);
-            } else if (categoriesState is CategoriesLoadInProgress ||
-                categoriesState is CategoriesInitial) {
-              return Column(
-                mainAxisAlignment: MainAxisAlignment.center,
-                children: [
-                  Center(
+          body: RefreshIndicator(
+            onRefresh: () {
+              DefaultCacheManager().emptyCache();
+              BlocProvider.of<CategoriesBloc>(context)
+                .add(CategoriesLoaded());
+              return;
+            },
+            child: () {
+              if (categoriesState is CategoriesLoadSuccess) {
+                return _buildCategoriesScreen(categoriesState.categories);
+              } else if (categoriesState is CategoriesImageLoadSuccess) {
+                return _buildCategoriesScreen(categoriesState.categories);
+              } else if (categoriesState is CategoriesLoadInProgress ||
+                  categoriesState is CategoriesInitial) {
+                return Column(
+                  mainAxisAlignment: MainAxisAlignment.center,children: [
+                    Center(
                     child: SpinKitWave(
                       color: Theme.of(context).primaryColor,
                       size: 50.0,
                     ),
                   ),
                   ApiVersionWarning(),
-                ],
-              );
-            } else if (categoriesState is CategoriesLoadFailure) {
-              return Padding(
-                padding: const EdgeInsets.all(8.0),
-                child: Column(
-                  children: [
-                    Text(
-                      translate('categories.errors.plugin_missing'),
-                      style: TextStyle(fontWeight: FontWeight.bold),
-                    ),
-                    Divider(),
-                    Text(translate('categories.errors.load_failed',
-                        args: {'error_msg': categoriesState.errorMsg})),
                   ],
-                ),
-              );
-            } else {
-              return Text(translate('categories.errors.unknown'));
-            }
-          }()),
+                );
+              } else if (categoriesState is CategoriesLoadFailure) {
+                return Padding(
+                  padding: const EdgeInsets.all(8.0),
+                  child: Column(
+                    children: [
+                      Text(
+                        translate('categories.errors.plugin_missing'),
+                        style: TextStyle(fontWeight: FontWeight.bold),
+                      ),
+                      Divider(),
+                      Text(translate('categories.errors.load_failed',
+                          args: {'error_msg': categoriesState.errorMsg})),
+                    ],
+                  ),
+                );
+              } else {
+                return Text(translate('categories.errors.unknown'));
+              }
+            }()
+          ),
         );
       },
     );

--- a/lib/src/screens/recipe_screen.dart
+++ b/lib/src/screens/recipe_screen.dart
@@ -54,6 +54,7 @@ class RecipeScreenState extends State<RecipeScreen> {
     DefaultCacheManager().emptyCache();
     this.setState(() {
     });
+    return Future.value(true);
   }
 
   @override

--- a/lib/src/screens/recipe_screen.dart
+++ b/lib/src/screens/recipe_screen.dart
@@ -2,6 +2,7 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_cache_manager/flutter_cache_manager.dart';
 import 'package:flutter_settings_screens/flutter_settings_screens.dart';
 import 'package:flutter_translate/flutter_translate.dart';
 import 'package:nextcloud_cookbook_flutter/src/blocs/recipe/recipe.dart';
@@ -47,6 +48,12 @@ class RecipeScreenState extends State<RecipeScreen> {
     _enableWakelock();
     recipeId = widget.recipeId;
     super.initState();
+  }
+
+  Future<void> _refresh() async {
+    DefaultCacheManager().emptyCache();
+    this.setState(() {
+    });
   }
 
   @override
@@ -99,23 +106,26 @@ class RecipeScreenState extends State<RecipeScreen> {
             floatingActionButton: state is RecipeLoadSuccess
                 ? _buildFabButton(state.recipe)
                 : null,
-            body: () {
-              if (state is RecipeLoadSuccess) {
-                return _buildRecipeScreen(state.recipe);
-              } else if (state is RecipeLoadInProgress) {
+            body:  RefreshIndicator(
+              onRefresh: _refresh,
+              child: () {
+                if (state is RecipeLoadSuccess) {
+                  return _buildRecipeScreen(state.recipe);
+                } else if (state is RecipeLoadInProgress) {
+                  return Center(
+                    child: CircularProgressIndicator(),
+                  );
+                } else if (state is RecipeFailure) {
                 return Center(
-                  child: CircularProgressIndicator(),
-                );
-              } else if (state is RecipeFailure) {
-                return Center(
-                  child: Text(state.errorMsg),
-                );
-              } else {
-                return Center(
-                  child: Text("FAILED"),
-                );
-              }
-            }(),
+                    child: Text(state.errorMsg),
+                  );
+                } else {
+                  return Center(
+                    child: Text("FAILED"),
+                  );
+                }
+              }(),
+            ),
           ),
         );
       }),

--- a/lib/src/screens/recipes_list_screen.dart
+++ b/lib/src/screens/recipes_list_screen.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_cache_manager/flutter_cache_manager.dart';
 import 'package:flutter_translate/flutter_translate.dart';
 import 'package:nextcloud_cookbook_flutter/src/blocs/recipes_short/recipes_short.dart';
 import 'package:nextcloud_cookbook_flutter/src/models/recipe_short.dart';
@@ -45,6 +46,7 @@ class RecipesListScreenState extends State<RecipesListScreen> {
                   semanticLabel: translate('app_bar.refresh'),
                 ),
                 onPressed: () {
+                  DefaultCacheManager().emptyCache();
                   BlocProvider.of<RecipesShortBloc>(context)
                       .add(RecipesShortLoaded(category: category));
                 },

--- a/lib/src/screens/recipes_list_screen.dart
+++ b/lib/src/screens/recipes_list_screen.dart
@@ -53,13 +53,21 @@ class RecipesListScreenState extends State<RecipesListScreen> {
               ),
             ],
           ),
-          body: (() {
-            if (recipesShortState is RecipesShortLoadSuccess) {
-              return _buildRecipesShortScreen(recipesShortState.recipesShort);
-            } else {
-              return Center(child: CircularProgressIndicator());
-            }
-          }()),
+          body: RefreshIndicator(
+            onRefresh: () {
+              DefaultCacheManager().emptyCache();
+              BlocProvider.of<RecipesShortBloc>(context)
+                  .add(RecipesShortLoaded(category: category));
+              return Future.value(true);
+            },
+            child:(() {
+              if (recipesShortState is RecipesShortLoadSuccess) {
+                return _buildRecipesShortScreen(recipesShortState.recipesShort);
+              } else {
+                return Center(child: CircularProgressIndicator());
+              }
+            }()),
+          ),
         );
       },
     );

--- a/lib/src/services/categories_provider.dart
+++ b/lib/src/services/categories_provider.dart
@@ -4,35 +4,34 @@ import 'package:nextcloud_cookbook_flutter/src/models/app_authentication.dart';
 import 'package:nextcloud_cookbook_flutter/src/models/category.dart';
 import 'package:nextcloud_cookbook_flutter/src/services/user_repository.dart';
 
+import 'network.dart';
+
 class CategoriesProvider {
   Future<List<Category>> fetchCategories() async {
     Dio client = UserRepository().getAuthenticatedClient();
     AppAuthentication appAuthentication =
         UserRepository().getCurrentAppAuthentication();
 
-    final response = await client
-        .get("${appAuthentication.server}/index.php/apps/cookbook/categories");
+    final String url = "${appAuthentication.server}/index.php/apps/cookbook/categories";
 
-    if (response.statusCode == 200) {
-      try {
-        List<Category> categories = Category.parseCategories(response.data);
-        categories.sort((a, b) => a.name.compareTo(b.name));
-        categories.insert(
-          0,
-          Category(
-            translate('categories.all_categories'),
-            categories.fold(
-                0,
-                (previousValue, element) =>
-                    previousValue + element.recipeCount),
-          ),
-        );
-        return categories;
-      } catch (e) {
-        throw Exception(e);
-      }
-    } else {
-      throw Exception(translate('categories.errors.load_no_response'));
+    // Parse categories
+    try {
+      String contents = await Network().get(url);
+      List<Category> categories = Category.parseCategories(contents);
+      categories.sort((a, b) => a.name.compareTo(b.name));
+      categories.insert(
+        0,
+        Category(
+          translate('categories.all_categories'),
+          categories.fold(
+              0,
+                  (previousValue, element) =>
+              previousValue + element.recipeCount),
+        ),
+      );
+      return categories;
+    } catch (e) {
+      throw Exception(e);
     }
   }
 }

--- a/lib/src/services/category_recipes_short_provider.dart
+++ b/lib/src/services/category_recipes_short_provider.dart
@@ -1,33 +1,31 @@
-import 'package:dio/dio.dart';
-import 'package:flutter_translate/flutter_translate.dart';
 import 'package:nextcloud_cookbook_flutter/src/models/app_authentication.dart';
 import 'package:nextcloud_cookbook_flutter/src/models/recipe_short.dart';
 import 'package:nextcloud_cookbook_flutter/src/services/user_repository.dart';
 import 'package:nextcloud_cookbook_flutter/src/services/version_provider.dart';
 
+import 'network.dart';
+
 class CategoryRecipesShortProvider {
   Future<List<RecipeShort>> fetchCategoryRecipesShort(String category) async {
     AndroidApiVersion androidApiVersion = UserRepository().getAndroidVersion();
-    Dio client = UserRepository().getAuthenticatedClient();
+
     AppAuthentication appAuthentication =
         UserRepository().getCurrentAppAuthentication();
 
-    Response response;
-    if (androidApiVersion == AndroidApiVersion.BEFORE_API_ENDPOINT) {
-      response = await client.get(
-          "${appAuthentication.server}/index.php/apps/cookbook/category/$category");
-    } else {
+    String url = "${appAuthentication.server}/index.php/apps/cookbook/category/$category";
+    if (androidApiVersion != AndroidApiVersion.BEFORE_API_ENDPOINT) {
       category = category == "*"
           ? "_"
           : category; // Mapping from * to _ for recipes without a category!
-      response = await client.get(
-          "${appAuthentication.server}/index.php/apps/cookbook/api/category/$category");
+      url = "${appAuthentication.server}/index.php/apps/cookbook/api/category/$category";
     }
 
-    if (response.statusCode == 200) {
-      return RecipeShort.parseRecipesShort(response.data);
-    } else {
-      throw Exception(translate('recipe_list.errors.load_failed'));
+    // Parse categories
+    try {
+      String contents = await Network().get(url);
+      return RecipeShort.parseRecipesShort(contents);
+    } catch (e) {
+      throw Exception(e);
     }
   }
 }

--- a/lib/src/services/network.dart
+++ b/lib/src/services/network.dart
@@ -1,0 +1,36 @@
+import 'package:flutter_cache_manager/flutter_cache_manager.dart';
+import 'package:nextcloud_cookbook_flutter/src/models/app_authentication.dart';
+import 'package:nextcloud_cookbook_flutter/src/services/user_repository.dart';
+
+class Network {
+  static final Network _network = Network._internal();
+
+  factory Network() {
+    return _network;
+  }
+
+  Network._internal();
+
+  /// Try to load file from locale cache first, if not available get it from the server
+  Future<String> get(String url) async {
+    AppAuthentication appAuthentication = UserRepository().getCurrentAppAuthentication();
+
+    FileInfo file = await DefaultCacheManager()
+        .getFileFromCache(url);
+    if (file == null) {
+      // Download, if not available
+      file = await DefaultCacheManager().
+      downloadFile(
+          url,
+          authHeaders: {
+            "authorization": appAuthentication.basicAuth,
+          }
+      );
+      if (file == null) {
+        throw Exception("could not download " + url);
+      }
+    }
+    String contents = await file.file.readAsString();
+    return contents;
+  }
+}

--- a/lib/src/services/notification_provider.dart
+++ b/lib/src/services/notification_provider.dart
@@ -35,6 +35,11 @@ class NotificationService {
   NotificationService._internal();
 
   Future<void> init() async {
+    // initialize Timezone Database
+    tz.initializeTimeZones();
+    tz.setLocalLocation(
+        tz.getLocation(await FlutterNativeTimezone.getLocalTimezone()));
+
     final AndroidInitializationSettings initializationSettingsAndroid =
         AndroidInitializationSettings('notification_icon');
 
@@ -58,11 +63,6 @@ class NotificationService {
       Timer timer = Timer.fromJson(data, element.id);
       if (timer.id > this.curId) this.curId = timer.id;
     });
-
-    // initialize Timezone Database
-    tz.initializeTimeZones();
-    tz.setLocalLocation(
-        tz.getLocation(await FlutterNativeTimezone.getLocalTimezone()));
   }
 
   int start(Timer timer) {

--- a/lib/src/services/recipes_short_provider.dart
+++ b/lib/src/services/recipes_short_provider.dart
@@ -1,22 +1,21 @@
-import 'package:dio/dio.dart';
 import 'package:flutter_translate/flutter_translate.dart';
 import 'package:nextcloud_cookbook_flutter/src/models/app_authentication.dart';
 import 'package:nextcloud_cookbook_flutter/src/models/recipe_short.dart';
 import 'package:nextcloud_cookbook_flutter/src/services/user_repository.dart';
 
+import 'network.dart';
+
 class RecipesShortProvider {
   Future<List<RecipeShort>> fetchRecipesShort() async {
-    Dio client = UserRepository().getAuthenticatedClient();
     AppAuthentication appAuthentication =
-        UserRepository().getCurrentAppAuthentication();
+    UserRepository().getCurrentAppAuthentication();
 
-    final response = await client.get(
-      "${appAuthentication.server}/index.php/apps/cookbook/api/recipes",
-    );
-
-    if (response.statusCode == 200) {
-      return RecipeShort.parseRecipesShort(response.data);
-    } else {
+    final String url = "${appAuthentication.server}/index.php/apps/cookbook/api/recipes";
+    try {
+      String contents = await Network().get(url);
+            return RecipeShort.parseRecipesShort(contents);
+    }
+    catch (e) {
       throw Exception(translate('recipe_list.errors.load_failed'));
     }
   }

--- a/lib/src/widget/authentication_cached_network_image.dart
+++ b/lib/src/widget/authentication_cached_network_image.dart
@@ -1,6 +1,5 @@
-import 'package:extended_image/extended_image.dart';
+import 'package:cached_network_image/cached_network_image.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter_svg/flutter_svg.dart';
 import 'package:nextcloud_cookbook_flutter/src/models/app_authentication.dart';
 import 'package:nextcloud_cookbook_flutter/src/services/user_repository.dart';
 
@@ -26,38 +25,16 @@ class AuthenticationCachedNetworkImage extends StatelessWidget {
 
     String settings = full ? "full" : "thumb";
 
-    return ExtendedImage.network(
-      '${appAuthentication.server}/index.php/apps/cookbook/recipes/$recipeId/image?size=$settings',
-      headers: {
-        "authorization": appAuthentication.basicAuth,
-      },
+    return CachedNetworkImage(
       fit: boxFit,
       width: width,
       height: height,
-      cache: true,
-      retries: 0,
-      loadStateChanged: (ExtendedImageState state) {
-        if (state.extendedImageLoadState == LoadState.loading) {
-          return Container(
-            width: width,
-            height: height,
-            color: Colors.grey[400],
-            child: Center(child: CircularProgressIndicator()),
-          );
-        } else if (state.extendedImageLoadState == LoadState.failed) {
-          return Container(
-            width: width,
-            height: height,
-            color: Colors.grey[400],
-            child: SvgPicture.asset(
-              'assets/icon.svg',
-              color: Colors.grey[600],
-            ),
-          );
-        } else {
-          return null;
-        }
+      httpHeaders: {
+        "authorization": appAuthentication.basicAuth,
       },
+      imageUrl: '${appAuthentication.server}/index.php/apps/cookbook/recipes/$recipeId/image?size=$settings',
+      placeholder: (context, url) => CircularProgressIndicator(),
+      errorWidget: (context, url, error) => Icon(Icons.error),
     );
   }
 }

--- a/lib/src/widget/authentication_cached_network_image.dart
+++ b/lib/src/widget/authentication_cached_network_image.dart
@@ -1,5 +1,6 @@
 import 'package:cached_network_image/cached_network_image.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_svg/flutter_svg.dart';
 import 'package:nextcloud_cookbook_flutter/src/models/app_authentication.dart';
 import 'package:nextcloud_cookbook_flutter/src/services/user_repository.dart';
 
@@ -32,9 +33,18 @@ class AuthenticationCachedNetworkImage extends StatelessWidget {
       httpHeaders: {
         "authorization": appAuthentication.basicAuth,
       },
-      imageUrl: '${appAuthentication.server}/index.php/apps/cookbook/recipes/$recipeId/image?size=$settings',
+      imageUrl:
+          '${appAuthentication.server}/index.php/apps/cookbook/recipes/$recipeId/image?size=$settings',
       placeholder: (context, url) => CircularProgressIndicator(),
-      errorWidget: (context, url, error) => Icon(Icons.error),
+      errorWidget: (context, url, error) => Container(
+        width: width,
+        height: height,
+        color: Colors.grey[400],
+        child: SvgPicture.asset(
+          'assets/icon.svg',
+          color: Colors.grey[600],
+        ),
+      ),
     );
   }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -63,7 +63,6 @@ dependencies:
   # Screen always on
   wakelock: ^0.5.2
 
-  extended_image: ^5.1.2
   xml: ^5.1.0
 
   flutter_spinkit: ^5.0.0
@@ -78,6 +77,8 @@ dependencies:
   flutter_local_notifications: ^8.2.0
   timer_builder: 2.0.0
   flutter_native_timezone: 2.0.0
+
+  cached_network_image: ^3.0.0
 
 dev_dependencies:
   flutter_launcher_icons: ^0.9.0


### PR DESCRIPTION
Added cached_network_image and flutter_cache_manager for better cache handling of all HTTP requests. Added RefreshIndicator for easier refresh.

cached_network_image and flutter_cache_manager are used in the [official flutter cookbooks ](https://flutter.dev/docs/cookbook/images/cached-images).

Clicking on the refresh buttons clears the cache, fixing
https://github.com/Teifun2/nextcloud-cookbook-flutter/issues/74