### PR TITLE
Fix recipe screen not switching to portrait layout from landscape

### DIFF
--- a/lib/src/screens/recipe/recipe_screen.dart
+++ b/lib/src/screens/recipe/recipe_screen.dart
@@ -67,9 +67,7 @@ class RecipeScreenState extends State<RecipeScreen> {
       ),
     );
 
-    if (MediaQuery.of(context).size.width > 600) {
-      this.isLargeScreen = true;
-    }
+    this.isLargeScreen = MediaQuery.of(context).size.width > 600;
     return BlocProvider<RecipeBloc>(
       create: (context) => RecipeBloc()..add(RecipeLoaded(recipeId: recipeId)),
       child: BlocBuilder<RecipeBloc, RecipeState>(


### PR DESCRIPTION
@Teifun2, first of all, thank you for making this mobile app for Nextcloud Cookbook. I started using the app on an android tablet, and I noticed that when the tablet was switched from landscape mode back to portrait mode while viewing a recipe, the screen stayed in the 3-column landscape layout instead of switching back to the single column portrait layout. This seems to be because the `isLargeScreen` boolean is not being reset to `false` when the screen size switches back. This PR updates the screen size check so that the layout can switch back and forth as the device is rotated.