### PR TITLE
Rename Edit button to Save

### DIFF
--- a/assets/i18n/en.json
+++ b/assets/i18n/en.json
@@ -111,7 +111,7 @@
   },
   "recipe_edit": {
     "title": "Edit Recipe",
-    "button": "Edit",
+    "button": "Save",
     "errors": {
       "update_failed": "Update Failed {error_msg}"
     }


### PR DESCRIPTION
Currently the button on the Edit Recipe page is titled "Edit" instead of "Save"
This fixes it for the English translation (I'm not sure how we change it for other languages).
