### PR TITLE
Add ingredient group headers and ability to tap ingredients to mark as used

### DIFF
--- a/lib/src/screens/recipe/recipe_screen.dart
+++ b/lib/src/screens/recipe/recipe_screen.dart
@@ -9,6 +9,7 @@ import 'package:flutter_translate/flutter_translate.dart';
 import 'package:nextcloud_cookbook_flutter/src/blocs/recipe/recipe.dart';
 import 'package:nextcloud_cookbook_flutter/src/models/recipe.dart';
 import 'package:nextcloud_cookbook_flutter/src/models/timer.dart';
+import 'package:nextcloud_cookbook_flutter/src/screens/recipe/widget/ingredient_list.dart';
 import 'package:nextcloud_cookbook_flutter/src/screens/recipe/widget/instruction_list.dart';
 import 'package:nextcloud_cookbook_flutter/src/screens/recipe/widget/nutrition_list.dart';
 import 'package:nextcloud_cookbook_flutter/src/screens/recipe_edit_screen.dart';
@@ -305,7 +306,7 @@ class RecipeScreenState extends State<RecipeScreen> {
                               ),
                               Expanded(
                                 flex: 5,
-                                child: this._buildRecipeIngredient(
+                                child: IngredientList(
                                     recipe, settingsBasedTextStyle),
                               ),
                               Expanded(
@@ -321,8 +322,7 @@ class RecipeScreenState extends State<RecipeScreen> {
                           if (recipe.nutrition.isNotEmpty)
                             NutritionList(recipe.nutrition),
                           if (recipe.recipeIngredient.isNotEmpty)
-                            this._buildRecipeIngredient(
-                                recipe, settingsBasedTextStyle),
+                            IngredientList(recipe, settingsBasedTextStyle),
                           InstructionList(recipe, settingsBasedTextStyle)
                         ]))
                 ],
@@ -332,32 +332,6 @@ class RecipeScreenState extends State<RecipeScreen> {
         );
       },
     );
-  }
-
-  Widget _buildRecipeIngredient(
-      Recipe recipe, TextStyle settingsBasedTextStyle) {
-    return Padding(
-        padding: const EdgeInsets.only(bottom: 10.0),
-        child: Theme(
-          data: Theme.of(context).copyWith(dividerColor: Colors.transparent),
-          child: ExpansionTile(
-            title: Text(translate('recipe.fields.ingredients')),
-            initiallyExpanded: true,
-            children: <Widget>[
-              Align(
-                alignment: Alignment.centerLeft,
-                child: Padding(
-                  padding: const EdgeInsets.only(left: 15.0),
-                  child: Text(
-                    recipe.recipeIngredient
-                        .fold("", (p, e) => p + "-  " + e.trim() + "\n"),
-                    style: settingsBasedTextStyle,
-                  ),
-                ),
-              ),
-            ],
-          ),
-        ));
   }
 
   Widget _showTimers(Recipe recipe) {

--- a/lib/src/screens/recipe/widget/ingredient_list.dart
+++ b/lib/src/screens/recipe/widget/ingredient_list.dart
@@ -3,11 +3,25 @@ import 'package:flutter/material.dart';
 import 'package:flutter_translate/flutter_translate.dart';
 import 'package:nextcloud_cookbook_flutter/src/models/recipe.dart';
 
-class IngredientList extends StatelessWidget {
+class IngredientList extends StatefulWidget {
   final Recipe _recipe;
   final TextStyle _textStyle;
 
   const IngredientList(this._recipe, this._textStyle);
+
+  @override
+  _IngredientListState createState() => _IngredientListState();
+}
+
+class _IngredientListState extends State<IngredientList> {
+  List<bool> _ingredientsDone;
+
+  @override
+  void initState() {
+    _ingredientsDone =
+        List.filled(widget._recipe.recipeIngredient.length, false);
+    super.initState();
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -25,13 +39,13 @@ class IngredientList extends StatelessWidget {
                 shrinkWrap: true,
                 physics: ClampingScrollPhysics(),
                 itemBuilder: (context, index) {
-                  return this._recipe.recipeIngredient[index].startsWith('##')
+                  return widget._recipe.recipeIngredient[index].startsWith('##')
                     ? Text(
-                        this._recipe.recipeIngredient[index].replaceFirst(
+                        widget._recipe.recipeIngredient[index].replaceFirst(
                           RegExp(r'##\s*'),
                           '',
                         ),
-                        style: this._textStyle.copyWith(
+                        style: widget._textStyle.copyWith(
                           fontFeatures:[FontFeature.enable('smcp')],
                         ),
                       )
@@ -39,25 +53,38 @@ class IngredientList extends StatelessWidget {
                         crossAxisAlignment: CrossAxisAlignment.start,
                         children: <Widget>[
                           Container(
-                            width: this._textStyle.fontSize * 1.5,
-                            height: this._textStyle.fontSize,
+                            width: widget._textStyle.fontSize * 1.5,
+                            height: widget._textStyle.fontSize,
                             alignment: Alignment.center,
-                            child: Icon(
-                              Icons.circle,
-                              size: this._textStyle.fontSize * 0.5,
-                            ),
+                            child: _ingredientsDone[index]
+                              ? Icon(
+                                  Icons.check_circle,
+                                  size: widget._textStyle.fontSize,
+                                  color: Colors.green,
+                                )
+                              : Icon(
+                                  Icons.circle,
+                                  size: widget._textStyle.fontSize * 0.5,
+                                ),
                           ),
                           Expanded(
-                            child: Text(
-                              this._recipe.recipeIngredient[index],
-                              style: this._textStyle,
+                            child: GestureDetector(
+                              onTap: () {
+                                setState(() {
+                                  _ingredientsDone[index] = !_ingredientsDone[index];
+                                });
+                              },
+                              child: Text(
+                                widget._recipe.recipeIngredient[index],
+                                style: widget._textStyle,
+                              ),
                             ),
                           ),
                         ],
                       );
                 },
                 separatorBuilder: (c, i) => SizedBox(height: 5),
-                itemCount: this._recipe.recipeIngredient.length,
+                itemCount: widget._recipe.recipeIngredient.length,
               ),
             ),
           ],

--- a/lib/src/screens/recipe/widget/ingredient_list.dart
+++ b/lib/src/screens/recipe/widget/ingredient_list.dart
@@ -1,0 +1,68 @@
+import 'dart:ui';
+import 'package:flutter/material.dart';
+import 'package:flutter_translate/flutter_translate.dart';
+import 'package:nextcloud_cookbook_flutter/src/models/recipe.dart';
+
+class IngredientList extends StatelessWidget {
+  final Recipe _recipe;
+  final TextStyle _textStyle;
+
+  const IngredientList(this._recipe, this._textStyle);
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 10.0),
+      child: Theme(
+        data: Theme.of(context).copyWith(dividerColor: Colors.transparent),
+        child: ExpansionTile(
+          title: Text(translate('recipe.fields.ingredients')),
+          initiallyExpanded: true,
+          children: <Widget>[
+            Padding(
+              padding: const EdgeInsets.symmetric(vertical: 8.0),
+              child: ListView.separated(
+                shrinkWrap: true,
+                physics: ClampingScrollPhysics(),
+                itemBuilder: (context, index) {
+                  return this._recipe.recipeIngredient[index].startsWith('##')
+                    ? Text(
+                        this._recipe.recipeIngredient[index].replaceFirst(
+                          RegExp(r'##\s*'),
+                          '',
+                        ),
+                        style: this._textStyle.copyWith(
+                          fontFeatures:[FontFeature.enable('smcp')],
+                        ),
+                      )
+                    : Row(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: <Widget>[
+                          Container(
+                            width: this._textStyle.fontSize * 1.5,
+                            height: this._textStyle.fontSize,
+                            alignment: Alignment.center,
+                            child: Icon(
+                              Icons.circle,
+                              size: this._textStyle.fontSize * 0.5,
+                            ),
+                          ),
+                          Expanded(
+                            child: Text(
+                              this._recipe.recipeIngredient[index],
+                              style: this._textStyle,
+                            ),
+                          ),
+                        ],
+                      );
+                },
+                separatorBuilder: (c, i) => SizedBox(height: 5),
+                itemCount: this._recipe.recipeIngredient.length,
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
This PR provides two updates to the ingredient list:

- The current plain text ingredient list is replaced with a new IngredientList widget that styles the ingredient list as a bulleted list. Ingredient items that are prefixed with "##" are styled as ingredient group headings without a bullet, matching the styling of the web app (fixes #133).
- Ingredient items can now be tapped to mark them as used (fixes #66). Tapping the ingredient text will change the bullet into a larger green circle check mark, similar to when the instructions are tapped. Tapping again reverts back to a standard bullet. 

Here is a screenshot showing an ingredient list before this PR is applied (version 0.7.6):
![Screenshot_before](https://user-images.githubusercontent.com/82246664/173241198-69d591a1-d8b6-4f7e-9ce1-3dc595ad2b2a.jpg)

Here is a screenshot of the same test recipe after the PR is applied, with the first ingredient checked:
![Screenshot_after_PR](https://user-images.githubusercontent.com/82246664/173241265-f218aa51-90ba-45d6-9600-018d1883c0ec.jpg)