### PR TITLE
Fix error when loading images for recipes.

### DIFF
--- a/lib/src/widget/authentication_cached_network_recipe_image.dart
+++ b/lib/src/widget/authentication_cached_network_recipe_image.dart
@@ -28,7 +28,7 @@ class AuthenticationCachedNetworkRecipeImage extends StatelessWidget {
 
     return AuthenticationCachedNetworkImage(
       url:
-          '${appAuthentication.server}/apps/cookbook/api/v1/recipes/$recipeId/image?size=$settings',
+          '${appAuthentication.server}/index.php/apps/cookbook/api/v1/recipes/$recipeId/image?size=$settings',
       width: width,
       height: height,
       boxFit: boxFit,


### PR DESCRIPTION
After the update to the latest version (0.7.7), the images of the recipes are not shown. Each HTTP requests ends with status code 406. With the `index.php` part in the URL the images are correctly loaded.