### PR TITLE
disable ci on draft pr

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,7 @@
 name: "Build"
 on:
   pull_request:
+    types: [review_requested, ready_for_review]
   push:
 jobs:
   build:


### PR DESCRIPTION
We could fix this by only running the CI when a review is requested. 

Another idea is (although I haven't used this condition before so I'm not shure it'll help) is adding a condition to the PR like:
```yaml
if: github.event.pull_request.draft == false
```
 [source](https://github.com/orgs/community/discussions/25722)
 
 ---
 
 EDIT: as I thought the my fix is working :)
 I just noticed that my IDE auto formated the yaml file in it's own mind so I'll revert that and only commit the one changed line.