### PR TITLE
Fix search bug

### DIFF
--- a/lib/src/services/data_repository.dart
+++ b/lib/src/services/data_repository.dart
@@ -89,7 +89,7 @@ class DataRepository {
   }
 
   Future<List<RecipeShort>> fetchAllRecipes() async {
-    return fetchRecipesShort(category: "All");
+    return fetchRecipesShort(category: categoryAll);
   }
 
   String getUserAvatarUrl() {


### PR DESCRIPTION
Fixes #64 

This pull request fixes the mentioned search bug. When fetching the recipe list for search, the category name "All" was used. This breaks search if language is not English. I changed it to use the translated categoryAll string.

Hope this is helpful and can be merged :)