### PR TITLE
Change landscape layout to use more space for Instructions

### DIFF
--- a/lib/src/screens/recipe_screen.dart
+++ b/lib/src/screens/recipe_screen.dart
@@ -131,12 +131,6 @@ class _RecipeScreenBodyState extends State<RecipeScreenBody> {
 
   @override
   Widget build(BuildContext context) {
-    final list = [
-      if (recipe.nutritionList.isNotEmpty) NutritionList(recipe.nutritionList),
-      if (recipe.recipeIngredient.isNotEmpty) IngredientList(recipe),
-      InstructionList(recipe),
-    ];
-
     final header = SliverList(
       delegate: SliverChildListDelegate.fixed([
         Padding(
@@ -159,14 +153,45 @@ class _RecipeScreenBodyState extends State<RecipeScreenBody> {
 
     final bottom = SliverList(
       delegate: SliverChildListDelegate.fixed([
-        if (recipe.tool.isNotEmpty) ToolList(recipe: recipe),
         if (MediaQuery.of(context).size.width > 600)
-          Row(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: list.map((e) => Expanded(flex: 5, child: e)).toList(),
-          )
+          ...[
+            Row(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                if (recipe.tool.isNotEmpty)
+                  Expanded(
+                    flex: 5,
+                    child: ToolList(recipe: recipe),
+                  ),
+                if (recipe.nutritionList.isNotEmpty)
+                  Expanded(
+                    flex: 5,
+                    child: NutritionList(recipe.nutritionList),
+                  ),
+              ]
+            ),
+            Row(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                if (recipe.recipeIngredient.isNotEmpty)
+                  Expanded(
+                    flex: 5,
+                    child: IngredientList(recipe),
+                  ),
+                Expanded(
+                  flex: 10,
+                  child: InstructionList(recipe),
+                ),
+              ]
+            ),
+          ]
         else
-          ...list,
+          ...[
+            if (recipe.tool.isNotEmpty) ToolList(recipe: recipe),
+            if (recipe.nutritionList.isNotEmpty) NutritionList(recipe.nutritionList),
+            if (recipe.recipeIngredient.isNotEmpty) IngredientList(recipe),
+            InstructionList(recipe),
+          ]
       ]),
     );
 

--- a/lib/src/screens/recipe_screen.dart
+++ b/lib/src/screens/recipe_screen.dart
@@ -160,15 +160,13 @@ class _RecipeScreenBodyState extends State<RecipeScreenBody> {
               children: [
                 if (recipe.tool.isNotEmpty)
                   Expanded(
-                    flex: 5,
                     child: ToolList(recipe: recipe),
                   ),
                 if (recipe.nutritionList.isNotEmpty)
                   Expanded(
-                    flex: 5,
                     child: NutritionList(recipe.nutritionList),
                   ),
-              ]
+              ],
             ),
             Row(
               crossAxisAlignment: CrossAxisAlignment.start,
@@ -182,7 +180,7 @@ class _RecipeScreenBodyState extends State<RecipeScreenBody> {
                   flex: 10,
                   child: InstructionList(recipe),
                 ),
-              ]
+              ],
             ),
           ]
         else


### PR DESCRIPTION
The current landscape layout uses 3 columns for nutrition info, ingredients, and instructions. On my tablet, this gives very little space for the instructions and can require a lot of scrolling for some recipes. In addition, even when a recipe does not contain nutrition info, the 3 columns are still used instead of hiding the nutrition area to provide more space for ingredients and instructions. Similar to @psleep in #161, I think a 2 column layout for ingredients and instructions would make the landscape view better and easier to use.

This PR moves the nutrition information up into the same row as the tools list when in landscape view, freeing up horizontal space for the ingredients and instructions. Since each instruction is usually longer than an ingredient, I made the instructions area twice the width of the ingredients list (and instructions become full width if there are no ingredients). If either the tools list or nutrition info is not present in the recipe, the corresponding area is not shown. This PR makes no changes to the portrait layout.

I'd welcome any feedback or suggestions for the new landscape layout. @psleep, is this what you were thinking of in your issue?

Here are a few before and after screenshots to show the changes:

**Original landscape layout** (same whether recipe has nutrition info or not)
![landscape_before](https://user-images.githubusercontent.com/82246664/229314442-173343b9-bb28-4859-b86e-6592535a0bc3.jpeg)

**New landscape layout - default after load**
![landscape_after](https://user-images.githubusercontent.com/82246664/229314506-22d69515-fe9e-4234-a751-dc5dc2a7174a.jpeg)

**New landscape layout - tools / nutrition expanded**
![landscape_after_expanded](https://user-images.githubusercontent.com/82246664/229314561-fa4717b1-35ce-457c-a411-542eba7bf8b0.jpeg)

**New landscape layout - no nutrition info**
![landscape_after_no_nutrition](https://user-images.githubusercontent.com/82246664/229314582-9cc2dd3b-fd3c-4c81-acea-235d7b391ac5.jpeg)

