### PR TITLE
Fix UserImage shape and ingredient group alignment

### DIFF
--- a/lib/src/widget/drawer.dart
+++ b/lib/src/widget/drawer.dart
@@ -22,7 +22,7 @@ class MainDrawer extends StatelessWidget {
               decoration: BoxDecoration(
                 color: Theme.of(context).colorScheme.primaryContainer,
               ),
-              child: const UserImage(),
+              child: const Center(child: UserImage()),
             ),
             DrawerItem(
               icon: Icons.alarm_add_outlined,

--- a/lib/src/widget/recipe/widget/ingredient_list.dart
+++ b/lib/src/widget/recipe/widget/ingredient_list.dart
@@ -12,6 +12,7 @@ class IngredientList extends StatelessWidget {
         childrenPadding: const EdgeInsets.symmetric(horizontal: 8),
         title: Text(translate('recipe.fields.ingredients')),
         initiallyExpanded: true,
+        expandedCrossAxisAlignment: CrossAxisAlignment.start,
         children: <Widget>[
           for (final ingredient in recipe.recipeIngredient)
             _IngredientListItem(ingredient)


### PR DESCRIPTION
This PR fixes #201. It restores the user image shown in the drawer to be a circle rather than an oval and aligns the ingredient group headers to the start of the column.